### PR TITLE
add setTokenURI and operator filter registry

### DIFF
--- a/contracts/Mintpeg.sol
+++ b/contracts/Mintpeg.sol
@@ -5,6 +5,7 @@ import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/common/ERC2981Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721URIStorageUpgradeable.sol";
 import "@openzeppelin/contracts/utils/Counters.sol";
+import "operator-filter-registry/src/IOperatorFilterRegistry.sol";
 
 import "./MintpegErrors.sol";
 
@@ -17,6 +18,10 @@ contract Mintpeg is
     OwnableUpgradeable
 {
     using Counters for Counters.Counter;
+
+    /// @notice Contract filtering allowed operators, preventing unauthorized contract to transfer NFTs
+    /// By default, Mintpeg contracts are subscribed to OpenSea's Curated Subscription Address at 0x3cc6CddA760b79bAfa08dF41ECFA224f810dCeB6
+    IOperatorFilterRegistry public operatorFilterRegistry;
 
     Counters.Counter private _tokenIds;
 
@@ -52,6 +57,28 @@ contract Mintpeg is
         uint96 _feePercent
     );
 
+    /// @dev Emitted on updateOperatorFilterRegistryAddress()
+    /// @param operatorFilterRegistry New operator filter registry
+    event OperatorFilterRegistryUpdated(
+        IOperatorFilterRegistry indexed operatorFilterRegistry
+    );
+
+    /// @notice Allow spending tokens from addresses with balance
+    /// Note that this still allows listings and marketplaces with escrow to transfer tokens if transferred
+    /// from an EOA.
+    modifier onlyAllowedOperator(address from) virtual {
+        if (from != msg.sender) {
+            _checkFilterOperator(msg.sender);
+        }
+        _;
+    }
+
+    /// @notice Allow approving tokens transfers
+    modifier onlyAllowedOperatorApproval(address operator) virtual {
+        _checkFilterOperator(operator);
+        _;
+    }
+
     /// @notice Mintpeg initialization
     /// @param _collectionName ERC721 name
     /// @param _collectionSymbol ERC721 symbol
@@ -69,6 +96,18 @@ contract Mintpeg is
         __ERC721_init(_collectionName, _collectionSymbol);
         setRoyaltyInfo(_royaltyReceiver, _feePercent);
         transferOwnership(_projectOwner);
+
+        // Initialize the operator filter registry and subcribe to OpenSea's list
+        IOperatorFilterRegistry _operatorFilterRegistry = IOperatorFilterRegistry(
+                0x000000000000AAeB6D7670E522A718067333cd4E
+            );
+        if (address(_operatorFilterRegistry).code.length > 0) {
+            _operatorFilterRegistry.registerAndSubscribe(
+                address(this),
+                0x3cc6CddA760b79bAfa08dF41ECFA224f810dCeB6
+            );
+        }
+        _updateOperatorFilterRegistryAddress(_operatorFilterRegistry);
 
         emit InitializedMintpeg(
             _collectionName,
@@ -156,6 +195,15 @@ contract Mintpeg is
         }
     }
 
+    /// @notice Update the address that the contract will make OperatorFilter checks against. When set to the zero
+    /// address, checks will be bypassed. OnlyOwner
+    /// @param _newRegistry The address of the new OperatorFilterRegistry
+    function updateOperatorFilterRegistryAddress(
+        IOperatorFilterRegistry _newRegistry
+    ) external onlyOwner {
+        _updateOperatorFilterRegistryAddress(_newRegistry);
+    }
+
     /// @notice Function to burn a token
     /// @dev Can only be called by token owner
     /// @param _tokenId Token ID to be burnt
@@ -182,5 +230,87 @@ contract Mintpeg is
             ERC721Upgradeable.supportsInterface(_interfaceId) ||
             ERC2981Upgradeable.supportsInterface(_interfaceId) ||
             super.supportsInterface(_interfaceId);
+    }
+
+    /// @dev Update the address that the contract will make OperatorFilter checks against. When set to the zero
+    /// address, checks will be bypassed.
+    /// @param _newRegistry The address of the new OperatorFilterRegistry
+    function _updateOperatorFilterRegistryAddress(
+        IOperatorFilterRegistry _newRegistry
+    ) private {
+        operatorFilterRegistry = _newRegistry;
+        emit OperatorFilterRegistryUpdated(_newRegistry);
+    }
+
+    /// @dev Checks if the address (the operator) trying to transfer the NFT is allowed
+    /// @param operator Address of the operator
+    function _checkFilterOperator(address operator) internal view virtual {
+        IOperatorFilterRegistry registry = operatorFilterRegistry;
+        // Check registry code length to facilitate testing in environments without a deployed registry.
+        if (address(registry).code.length > 0) {
+            if (!registry.isOperatorAllowed(address(this), operator)) {
+                revert Mintpeg__OperatorNotAllowed(operator);
+            }
+        }
+    }
+
+    /// @dev `setApprovalForAll` wrapper to prevent the sender to approve a non-allowed operator
+    /// @param operator Address being approved
+    /// @param approved Whether the operator is approved or not
+    function setApprovalForAll(address operator, bool approved)
+        public
+        override
+        onlyAllowedOperatorApproval(operator)
+    {
+        super.setApprovalForAll(operator, approved);
+    }
+
+    /// @dev `aprove` wrapper to prevent the sender to approve a non-allowed operator
+    /// @param operator Address being approved
+    /// @param tokenId TokenID approved
+    function approve(address operator, uint256 tokenId)
+        public
+        override
+        onlyAllowedOperatorApproval(operator)
+    {
+        super.approve(operator, tokenId);
+    }
+
+    /// @dev `transferFrom` wrapper to prevent a non-allowed operator to transfer the NFT
+    /// @param from Address to transfer from
+    /// @param to Address to transfer to
+    /// @param tokenId TokenID to transfer
+    function transferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    ) public override onlyAllowedOperator(from) {
+        super.transferFrom(from, to, tokenId);
+    }
+
+    /// @dev `safeTransferFrom` wrapper to prevent a non-allowed operator to transfer the NFT
+    /// @param from Address to transfer from
+    /// @param to Address to transfer to
+    /// @param tokenId TokenID to transfer
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    ) public override onlyAllowedOperator(from) {
+        super.safeTransferFrom(from, to, tokenId);
+    }
+
+    /// @dev `safeTransferFrom` wrapper to prevent a non-allowed operator to transfer the NFT
+    /// @param from Address to transfer from
+    /// @param to Address to transfer to
+    /// @param tokenId TokenID to transfer
+    /// @param data Data to send along with a safe transfer check
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId,
+        bytes memory data
+    ) public override onlyAllowedOperator(from) {
+        super.safeTransferFrom(from, to, tokenId, data);
     }
 }

--- a/contracts/Mintpeg.sol
+++ b/contracts/Mintpeg.sol
@@ -128,6 +128,34 @@ contract Mintpeg is
         emit TokenRoyaltyInfoChanged(_tokenId, _royaltyReceiver, _feePercent);
     }
 
+    /// @notice Function for changing individual token URI
+    /// @dev Can only be called by project owner
+    /// @param _tokenId Token ID that will have URI changed
+    /// @param _tokenURI Token URI to change to
+    function setTokenURI(uint256 _tokenId, string memory _tokenURI)
+        public
+        onlyOwner
+    {
+        _setTokenURI(_tokenId, _tokenURI);
+    }
+
+    /// @notice Function for changing multiple token URIs
+    /// @dev Can only be called by project owner
+    /// @param _ids Token IDs that will have URI changed
+    /// @param _URIs Token URIs to change to
+    function setTokenURIs(uint256[] memory _ids, string[] memory _URIs)
+        public
+        onlyOwner
+    {
+        uint256 length = _ids.length;
+        if (length != _URIs.length) {
+            revert Mintpeg__InvalidLength();
+        }
+        for (uint256 i; i < length; i++) {
+            _setTokenURI(_ids[i], _URIs[i]);
+        }
+    }
+
     /// @notice Function to burn a token
     /// @dev Can only be called by token owner
     /// @param _tokenId Token ID to be burnt

--- a/contracts/MintpegErrors.sol
+++ b/contracts/MintpegErrors.sol
@@ -4,4 +4,5 @@ pragma solidity ^0.8.7;
 error Mintpeg__InvalidRoyaltyInfo();
 error Mintpeg__InvalidProjectOwner();
 error Mintpeg__InvalidTokenOwner();
+error Mintpeg__InvalidLength();
 error MintpegFactory__InvalidMintpegImplementation();

--- a/contracts/MintpegErrors.sol
+++ b/contracts/MintpegErrors.sol
@@ -6,3 +6,4 @@ error Mintpeg__InvalidProjectOwner();
 error Mintpeg__InvalidTokenOwner();
 error Mintpeg__InvalidLength();
 error MintpegFactory__InvalidMintpegImplementation();
+error Mintpeg__OperatorNotAllowed(address operator);

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -10,7 +10,16 @@ glob.sync("./tasks/**/*.ts").forEach(function (file) {
 });
 
 module.exports = {
-  solidity: "0.8.7",
+  solidity: {
+    compilers: [
+      {
+        version: "0.8.7",
+      },
+      {
+        version: "0.8.13",
+      },
+    ],
+  },
   networks: {
     hardhat: {},
     fuji: {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "solidity-coverage": "^0.7.21",
     "ts-node": ">=8.0.0",
     "typechain": "^8.1.0",
-    "typescript": ">=4.5.0"
+    "typescript": ">=4.5.0",
+    "operator-filter-registry": "^1.3.1"
   },
   "dependencies": {
     "@openzeppelin/contracts": "^4.7.1",

--- a/test/Mintpeg.sol/OperatorFilterRegistry.test.ts
+++ b/test/Mintpeg.sol/OperatorFilterRegistry.test.ts
@@ -1,0 +1,429 @@
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { config as hardhatConfig, ethers, network } from "hardhat";
+
+describe("OperatorFilterRegistry", function () {
+  let mintpegCF: ContractFactory;
+  let mintpeg: Contract;
+  let filterRegistry: Contract;
+  let osOwnedRegistrant: Contract;
+
+  let signers: SignerWithAddress[];
+  let dev: SignerWithAddress;
+  let alice: SignerWithAddress;
+  let bob: SignerWithAddress;
+  let royaltyReceiver: SignerWithAddress;
+  let registrantOwner: SignerWithAddress;
+
+  const abi = ethers.utils.defaultAbiCoder;
+
+  const deployFixture = async () => {
+    const rpcConfig: any = hardhatConfig.networks.avalanche;
+    await network.provider.request({
+      method: "hardhat_reset",
+      params: [
+        {
+          forking: {
+            jsonRpcUrl: rpcConfig.url,
+          },
+          live: false,
+          saveDeployments: true,
+          tags: ["test", "local"],
+        },
+      ],
+    });
+
+    await network.provider.request({
+      method: "hardhat_impersonateAccount",
+      params: [await osOwnedRegistrant.owner()],
+    });
+
+    await network.provider.send("hardhat_setBalance", [
+      await osOwnedRegistrant.owner(),
+      "0x100000000000000000000000",
+    ]);
+
+    await deployMintpeg();
+
+    registrantOwner = await ethers.getSigner(await osOwnedRegistrant.owner());
+  };
+
+  const deployMintpeg = async () => {
+    mintpeg = await mintpegCF.deploy();
+    await mintpeg.initialize(
+      "JoePEG",
+      "JOEPEG",
+      dev.address,
+      royaltyReceiver.address,
+      100
+    );
+
+    await mintpeg.mint([
+      "token0.joepegs.com",
+      "token1.joepegs.com",
+      "token2.joepegs.com",
+      "token3.joepegs.com",
+    ]);
+  };
+
+  // Selector for "AddressFiltered(address)" error
+  const addressFilteredError = (address: string) =>
+    `0xa8cf495d${abi.encode(["address"], [address]).slice(2)}`;
+
+  before(async () => {
+    mintpegCF = await ethers.getContractFactory("Mintpeg");
+    filterRegistry = await ethers.getContractAt(
+      "IOperatorFilterRegistry",
+      "0x000000000000AAeB6D7670E522A718067333cd4E"
+    );
+    osOwnedRegistrant = await ethers.getContractAt(
+      "OwnableUpgradeable",
+      "0x3cc6CddA760b79bAfa08dF41ECFA224f810dCeB6"
+    );
+
+    signers = await ethers.getSigners();
+    dev = signers[0];
+    alice = signers[1];
+    bob = signers[2];
+    royaltyReceiver = signers[3];
+  });
+
+  beforeEach(async () => {
+    await loadFixture(deployFixture);
+  });
+
+  describe("Using OpenSea list", async () => {
+    const nftID = 1;
+
+    it("Should be corretly setup", async () => {
+      expect(await mintpeg.operatorFilterRegistry()).to.equal(
+        filterRegistry.address
+      );
+      expect(await filterRegistry.callStatic.isRegistered(mintpeg.address)).to
+        .be.true;
+      expect(
+        await filterRegistry.callStatic.subscriptionOf(mintpeg.address)
+      ).to.be.equal(osOwnedRegistrant.address);
+    });
+
+    it("Should be transferable by operators", async () => {
+      await mintpeg.setApprovalForAll(alice.address, true);
+      await mintpeg
+        .connect(alice)
+        .transferFrom(dev.address, bob.address, nftID);
+      expect(await mintpeg.ownerOf(nftID)).to.equal(bob.address);
+
+      await mintpeg.connect(bob).approve(alice.address, nftID);
+      await mintpeg
+        .connect(alice)
+        .transferFrom(bob.address, dev.address, nftID);
+      expect(await mintpeg.ownerOf(nftID)).to.equal(dev.address);
+    });
+
+    it("Should block individual approvals if the operator is blocked", async () => {
+      await filterRegistry
+        .connect(registrantOwner)
+        .updateOperator(osOwnedRegistrant.address, alice.address, true);
+      // Hardhat doesn't seem to recognize custom revert reasons from external contracts
+      // Doing a static call is a workaround
+      await expect(
+        mintpeg.callStatic.approve(alice.address, nftID)
+      ).to.be.rejectedWith(addressFilteredError(alice.address));
+    });
+
+    it("Should block approvals for all if the operator is blocked", async () => {
+      await filterRegistry
+        .connect(registrantOwner)
+        .updateOperator(osOwnedRegistrant.address, alice.address, true);
+      await expect(
+        mintpeg.callStatic.setApprovalForAll(alice.address, true)
+      ).to.be.rejectedWith(addressFilteredError(alice.address));
+    });
+
+    it("Should block transfers if the operator is blocked", async () => {
+      await mintpeg.setApprovalForAll(alice.address, true);
+      await filterRegistry
+        .connect(registrantOwner)
+        .updateOperator(osOwnedRegistrant.address, alice.address, true);
+
+      await expect(
+        mintpeg
+          .connect(alice)
+          .callStatic.transferFrom(dev.address, bob.address, nftID)
+      ).to.be.rejectedWith(addressFilteredError(alice.address));
+
+      expect(await mintpeg.ownerOf(nftID)).to.equal(dev.address);
+    });
+
+    it("Should block safe transfers if the operator is blocked", async () => {
+      await mintpeg.setApprovalForAll(alice.address, true);
+      await filterRegistry
+        .connect(registrantOwner)
+        .updateOperator(osOwnedRegistrant.address, alice.address, true);
+
+      await expect(
+        mintpeg
+          .connect(alice)
+          .callStatic["safeTransferFrom(address,address,uint256)"](
+            dev.address,
+            bob.address,
+            nftID
+          )
+      ).to.be.rejectedWith(addressFilteredError(alice.address));
+
+      await expect(
+        mintpeg
+          .connect(alice)
+          .callStatic["safeTransferFrom(address,address,uint256,bytes)"](
+            dev.address,
+            bob.address,
+            nftID,
+            []
+          )
+      ).to.be.rejectedWith(addressFilteredError(alice.address));
+
+      expect(await mintpeg.ownerOf(nftID)).to.equal(dev.address);
+    });
+
+    it("Should allow transfers back if the operator is unblocked", async () => {
+      await mintpeg.setApprovalForAll(alice.address, true);
+      await filterRegistry
+        .connect(registrantOwner)
+        .updateOperator(osOwnedRegistrant.address, alice.address, true);
+
+      await expect(
+        mintpeg
+          .connect(alice)
+          .callStatic.transferFrom(dev.address, bob.address, nftID)
+      ).to.be.rejectedWith(addressFilteredError(alice.address));
+
+      expect(await mintpeg.ownerOf(nftID)).to.equal(dev.address);
+
+      await filterRegistry
+        .connect(registrantOwner)
+        .updateOperator(osOwnedRegistrant.address, alice.address, false);
+      await mintpeg
+        .connect(alice)
+        .transferFrom(dev.address, bob.address, nftID);
+
+      expect(await mintpeg.ownerOf(nftID)).to.equal(bob.address);
+    });
+
+    it("Should disable the filter if the address is updated to address zero", async () => {
+      await filterRegistry
+        .connect(registrantOwner)
+        .updateOperator(osOwnedRegistrant.address, alice.address, true);
+      await expect(
+        mintpeg.callStatic.approve(alice.address, nftID)
+      ).to.be.rejectedWith(addressFilteredError(alice.address));
+
+      await mintpeg.updateOperatorFilterRegistryAddress(
+        ethers.constants.AddressZero
+      );
+
+      await mintpeg.approve(alice.address, nftID);
+      expect(await mintpeg.getApproved(nftID)).to.equal(alice.address);
+
+      await mintpeg
+        .connect(alice)
+        .transferFrom(dev.address, bob.address, nftID);
+      expect(await mintpeg.ownerOf(nftID)).to.equal(bob.address);
+    });
+
+    it("Should disable the filter if mintpeg is unregistered", async () => {
+      await filterRegistry
+        .connect(registrantOwner)
+        .updateOperator(osOwnedRegistrant.address, alice.address, true);
+      await expect(
+        mintpeg.callStatic.approve(alice.address, nftID)
+      ).to.be.rejectedWith(addressFilteredError(alice.address));
+
+      await filterRegistry.unregister(mintpeg.address);
+
+      await mintpeg.approve(alice.address, nftID);
+      expect(await mintpeg.getApproved(nftID)).to.equal(alice.address);
+
+      await mintpeg
+        .connect(alice)
+        .transferFrom(dev.address, bob.address, nftID);
+      expect(await mintpeg.ownerOf(nftID)).to.equal(bob.address);
+    });
+
+    it("Shouldn't be possible to update the filter registry address if the caller is not the owner", async () => {
+      await expect(
+        mintpeg
+          .connect(alice)
+          .updateOperatorFilterRegistryAddress(filterRegistry.address)
+      ).to.be.rejectedWith("Ownable: caller is not the owner");
+    });
+
+    it("Shouldn't be possible to update the filter registry list if the caller is not the owner", async () => {
+      await expect(
+        filterRegistry
+          .connect(alice)
+          .callStatic.updateOperator(
+            osOwnedRegistrant.address,
+            alice.address,
+            false
+          )
+      ).to.be.rejectedWith("0xfcf5eff8"); // OnlyAddressOrOwner()
+    });
+  });
+
+  describe("Using custom list", async () => {
+    const nftID = 1;
+
+    beforeEach(async () => {
+      // Opensea blocks Alice
+      await filterRegistry
+        .connect(registrantOwner)
+        .updateOperator(osOwnedRegistrant.address, alice.address, true);
+      // Joepegs forks from Opensea's list
+      await filterRegistry.unregister(mintpeg.address);
+      await filterRegistry.registerAndCopyEntries(
+        mintpeg.address,
+        osOwnedRegistrant.address
+      );
+    });
+
+    it("Should block individual approvals if the operator is blocked for new and previous operators", async () => {
+      await filterRegistry.updateOperator(mintpeg.address, bob.address, true);
+
+      await expect(
+        mintpeg.callStatic.approve(alice.address, nftID)
+      ).to.be.rejectedWith(addressFilteredError(alice.address));
+
+      await expect(
+        mintpeg.callStatic.approve(bob.address, nftID)
+      ).to.be.rejectedWith(addressFilteredError(bob.address));
+    });
+
+    it("Should block approvals for all if the operator is blocked for new and previous operators", async () => {
+      await filterRegistry.updateOperator(mintpeg.address, bob.address, true);
+
+      await expect(
+        mintpeg.callStatic.setApprovalForAll(alice.address, true)
+      ).to.be.rejectedWith(addressFilteredError(alice.address));
+
+      await expect(
+        mintpeg.callStatic.setApprovalForAll(bob.address, true)
+      ).to.be.rejectedWith(addressFilteredError(bob.address));
+    });
+
+    it("Should block transfers if the operator is blocked for new  operators", async () => {
+      await mintpeg.setApprovalForAll(bob.address, true);
+
+      await filterRegistry.updateOperator(mintpeg.address, bob.address, true);
+
+      await expect(
+        mintpeg
+          .connect(bob)
+          .callStatic.transferFrom(dev.address, bob.address, nftID)
+      ).to.be.rejectedWith(addressFilteredError(bob.address));
+
+      expect(await mintpeg.ownerOf(nftID)).to.equal(dev.address);
+    });
+
+    it("Should block safe transfers if the operator is blocked for new operators", async () => {
+      await mintpeg.setApprovalForAll(bob.address, true);
+
+      await filterRegistry.updateOperator(mintpeg.address, bob.address, true);
+
+      await expect(
+        mintpeg
+          .connect(bob)
+          .callStatic["safeTransferFrom(address,address,uint256)"](
+            dev.address,
+            bob.address,
+            nftID
+          )
+      ).to.be.rejectedWith(addressFilteredError(bob.address));
+
+      await expect(
+        mintpeg
+          .connect(bob)
+          .callStatic["safeTransferFrom(address,address,uint256,bytes)"](
+            dev.address,
+            bob.address,
+            nftID,
+            []
+          )
+      ).to.be.rejectedWith(addressFilteredError(bob.address));
+
+      expect(await mintpeg.ownerOf(nftID)).to.equal(dev.address);
+    });
+
+    it("Should allow transfers back if the operator is unblocked for new and previous operators", async () => {
+      await mintpeg.setApprovalForAll(bob.address, true);
+
+      await filterRegistry.updateOperator(mintpeg.address, bob.address, true);
+
+      await expect(
+        mintpeg
+          .connect(bob)
+          .callStatic.transferFrom(dev.address, bob.address, nftID)
+      ).to.be.rejectedWith(addressFilteredError(bob.address));
+
+      expect(await mintpeg.ownerOf(nftID)).to.equal(dev.address);
+
+      await filterRegistry.updateOperator(mintpeg.address, bob.address, false);
+      await mintpeg.connect(bob).transferFrom(dev.address, bob.address, nftID);
+
+      expect(await mintpeg.ownerOf(nftID)).to.equal(bob.address);
+    });
+
+    it("Should disable the filter if the address is updated to address zero for new and previous operators", async () => {
+      await filterRegistry.updateOperator(mintpeg.address, bob.address, true);
+
+      await expect(
+        mintpeg.callStatic.approve(bob.address, nftID)
+      ).to.be.rejectedWith(addressFilteredError(bob.address));
+
+      await mintpeg.updateOperatorFilterRegistryAddress(
+        ethers.constants.AddressZero
+      );
+
+      await mintpeg.approve(bob.address, nftID);
+      expect(await mintpeg.getApproved(nftID)).to.equal(bob.address);
+
+      await mintpeg.connect(bob).transferFrom(dev.address, bob.address, nftID);
+      expect(await mintpeg.ownerOf(nftID)).to.equal(bob.address);
+
+      await mintpeg.approve(alice.address, nftID + 1);
+      expect(await mintpeg.getApproved(nftID + 1)).to.equal(alice.address);
+
+      await mintpeg
+        .connect(alice)
+        .transferFrom(dev.address, bob.address, nftID + 1);
+      expect(await mintpeg.ownerOf(nftID + 1)).to.equal(bob.address);
+    });
+
+    it("Should disable the filter if mintpeg is unregistered for new and previous operators", async () => {
+      await filterRegistry.updateOperator(mintpeg.address, bob.address, true);
+
+      await expect(
+        mintpeg.callStatic.approve(bob.address, nftID)
+      ).to.be.rejectedWith(addressFilteredError(bob.address));
+
+      await filterRegistry.unregister(mintpeg.address);
+
+      await mintpeg.approve(alice.address, nftID);
+      expect(await mintpeg.getApproved(nftID)).to.equal(alice.address);
+
+      await mintpeg
+        .connect(alice)
+        .transferFrom(dev.address, bob.address, nftID);
+      expect(await mintpeg.ownerOf(nftID)).to.equal(bob.address);
+
+      await mintpeg.approve(bob.address, nftID + 1);
+      expect(await mintpeg.getApproved(nftID + 1)).to.equal(bob.address);
+
+      await mintpeg
+        .connect(bob)
+        .transferFrom(dev.address, bob.address, nftID + 1);
+      expect(await mintpeg.ownerOf(nftID + 1)).to.equal(bob.address);
+    });
+  });
+});

--- a/test/Mintpeg.sol/changeURI.test.ts
+++ b/test/Mintpeg.sol/changeURI.test.ts
@@ -1,0 +1,81 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { BigNumber, Contract, ContractFactory } from "ethers";
+import { MintpegInitProps, initializeMintpeg } from "../utils/helpers";
+
+describe("token URIs", () => {
+  let dev: SignerWithAddress;
+  let alice: SignerWithAddress;
+  let Mintpeg: Contract;
+  let MintpegCF: ContractFactory;
+  let mintpegInit: MintpegInitProps;
+  const tokenURIs: string[] = ["token0.joepegs.com", "token1.joepegs.com"];
+  const newTokenURIs: string[] = [
+    "new.token0.joepegs.com",
+    "new.token1.joepegs.com",
+  ];
+
+  beforeEach(async () => {
+    [dev, alice] = await ethers.getSigners();
+    MintpegCF = await ethers.getContractFactory("Mintpeg");
+    Mintpeg = await MintpegCF.deploy();
+    await Mintpeg.deployed();
+    mintpegInit = {
+      _collectionName: "JoePEG",
+      _collectionSymbol: "JPG",
+      _projectOwner: dev.address,
+      _royaltyReceiver: dev.address,
+      _feePercent: 500,
+    };
+  });
+
+  it("should be able to change single token URI", async () => {
+    await initializeMintpeg(Mintpeg, {}, mintpegInit);
+    await Mintpeg.connect(dev).mint(tokenURIs);
+    expect(await Mintpeg.tokenURI(0)).to.be.equal(tokenURIs[0]);
+    expect(await Mintpeg.tokenURI(1)).to.be.equal(tokenURIs[1]);
+
+    await Mintpeg.connect(dev).setTokenURI(0, newTokenURIs[0]);
+
+    expect(await Mintpeg.tokenURI(0)).to.be.equal(newTokenURIs[0]);
+    expect(await Mintpeg.tokenURI(1)).to.be.equal(tokenURIs[1]);
+  });
+
+  it("should be able to change multiple token URIs", async () => {
+    await initializeMintpeg(Mintpeg, {}, mintpegInit);
+    await Mintpeg.connect(dev).mint(tokenURIs);
+    expect(await Mintpeg.tokenURI(0)).to.be.equal(tokenURIs[0]);
+    expect(await Mintpeg.tokenURI(1)).to.be.equal(tokenURIs[1]);
+
+    await Mintpeg.connect(dev).setTokenURIs([0, 1], newTokenURIs);
+
+    expect(await Mintpeg.tokenURI(0)).to.be.equal(newTokenURIs[0]);
+    expect(await Mintpeg.tokenURI(1)).to.be.equal(newTokenURIs[1]);
+  });
+
+  it("token URI should be changable only by Owner", async () => {
+    await initializeMintpeg(Mintpeg, {}, mintpegInit);
+    await Mintpeg.connect(dev).mint(tokenURIs);
+    await Mintpeg.connect(dev).transferFrom(dev.address, alice.address, 0);
+    await expect(
+      Mintpeg.connect(alice).setTokenURI(0, newTokenURIs[0])
+    ).to.be.revertedWith("Ownable: caller is not the owner");
+    await expect(
+      Mintpeg.connect(alice).setTokenURIs([0, 1], newTokenURIs)
+    ).to.be.revertedWith("Ownable: caller is not the owner");
+
+    expect(await Mintpeg.tokenURI(0)).to.be.equal(tokenURIs[0]);
+    expect(await Mintpeg.tokenURI(1)).to.be.equal(tokenURIs[1]);
+  });
+
+  it("should revert if invalid lengths", async () => {
+    await initializeMintpeg(Mintpeg, {}, mintpegInit);
+    await Mintpeg.connect(dev).mint(tokenURIs);
+
+    await expect(Mintpeg.connect(dev).setTokenURIs([0], newTokenURIs)).to.be
+      .reverted;
+    await expect(Mintpeg.connect(dev).setTokenURIs([0, 1], [newTokenURIs[0]]))
+      .to.be.reverted;
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -529,10 +529,20 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.7.1.tgz#f63fc384255d6ac139e0a2561aa207fd7c14183c"
   integrity sha512-5EFiZld3DYFd8aTL8eeMnhnaWh1/oXLXFNuFMrgF3b1DNPshF3LCyO7VR6lc+gac2URJ0BlVcZoCfkk/3MoEfg==
 
+"@openzeppelin/contracts-upgradeable@^4.8.0":
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.8.1.tgz#363f7dd08f25f8f77e16d374350c3d6b43340a7a"
+  integrity sha512-1wTv+20lNiC0R07jyIAbHU7TNHKRwGiTGRfiNnA8jOWjKT98g5OgLpYWOi40Vgpk8SPLA9EvfJAbAeIyVn+7Bw==
+
 "@openzeppelin/contracts@^4.7.1":
   version "4.7.1"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.7.1.tgz#33d0a857b76b18d313e6bb6ed28cdaf367e90cfe"
   integrity sha512-UXmAjKARsXORHlHZu5GCD7ZbRKm6nU8UHnbuT/QJJa2JEOEcbvV/X8w/sUk62Sl9VZuuljM1akrZLyAtzUgsxw==
+
+"@openzeppelin/contracts@^4.7.3":
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.8.1.tgz#709cfc4bbb3ca9f4460d60101f15dac6b7a2d5e4"
+  integrity sha512-xQ6eUZl+RDyb/FiZe1h+U7qr/f4p/SrTSQcTPH2bjur3C5DbuW/zFgCU/b1P/xcIaEqJep+9ju4xDRi3rmChdQ==
 
 "@scure/base@~1.1.0":
   version "1.1.1"
@@ -4301,6 +4311,14 @@ once@1.x, once@^1.3.0, once@^1.3.1, once@^1.4.0:
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
   dependencies:
     wrappy "1"
+
+operator-filter-registry@^1.3.1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/operator-filter-registry/-/operator-filter-registry-1.4.0.tgz#3933fb0e4dba862bbb9655506a89becf0bdc0f32"
+  integrity sha512-BPm5/oF/mLobK8Or795wmQqHx/j0eKMv35Z4HQWTykBPGJHyFUUBsVreo4Z8cj2f0m/3IbQJTHwml6dm3crkPQ==
+  dependencies:
+    "@openzeppelin/contracts" "^4.7.3"
+    "@openzeppelin/contracts-upgradeable" "^4.8.0"
 
 optionator@^0.8.1:
   version "0.8.3"


### PR DESCRIPTION
In this PR I 
1) add functions that enable contract owner to change minted token URIs
2) add Operator Filter Registry. Based on https://github.com/traderjoe-xyz/launchpeg-v2/pull/13 without extra modifications